### PR TITLE
Add support for "collapsed" interface headers

### DIFF
--- a/index.php
+++ b/index.php
@@ -39,7 +39,12 @@
         print "<ul class=\"iface\">\n";
         foreach ($iface_list as $if)
         {
-            print "<li class=\"iface\">";
+            if ($iface == $if) {
+                print "<li class=\"iface active\">";
+            } else {
+                print "<li class=\"iface\">";
+            }
+            print "<a href=\"$script?if=$if$p\">";
             if (isset($iface_title[$if]))
             {
                 print $iface_title[$if];
@@ -48,6 +53,7 @@
             {
                 print $if;
             }
+            print "</a>";
             print "<ul class=\"page\">\n";
             foreach ($page_list as $pg)
             {

--- a/themes/light/style.css
+++ b/themes/light/style.css
@@ -26,13 +26,20 @@ body
     background-color: #eef;
 }
 
+#sidebar li.iface ul
+{
+    display: none;
+}
+#sidebar li.iface.active ul
+{
+    display: block;
+}
 #sidebar li.iface
 {
-    margin: 0;
+    margin: 2px;
     padding: 0;
     list-style-type: none;
-    font-family: 'Trebuchet MS', Verdana, sans-serif;
-    font-size: 1em;
+    font-size: 12px;
     font-weight: bold;
     xborder-top: 1px solid #99b;
     border-bottom: 1px solid #99b;


### PR DESCRIPTION
In situations where there are a lot of interfaces being monitored it is convenient to hide the links to "summary" et al for interfaces which you are not actively viewing, so as to conserve screen real estate.

This patch does this by adding an "active" class to the currently-selected interface, and adding a few tweaks to the style.css for the light theme. There are also some other minor CSS tweaks to improve(IMO) the appearance of the #sidebar li.iface block, which you may or may not want to merge.

I considered adding a config variable to toggle the addition of the "active" CSS class, but I came to the conclusion that this tweak is better done in CSS.
