### PR TITLE
Fix array to string conversion in graphs

### DIFF
--- a/graph_svg.php
+++ b/graph_svg.php
@@ -153,7 +153,7 @@
 
 	// draw title
 	$text = T('Traffic data for')." $iface";
-	svg_text($iw / 2, ($ytm / 2), $text, array( 'stroke' => $cl['text'], 'fill' => $cl['text']['rgb'],'stroke-width' => 0, 'font-family' => SVG_FONT, 'font-weight' => 'bold', 'text-anchor' => 'middle' ));
+	svg_text($iw / 2, ($ytm / 2), $text, array( 'stroke' => 'none', 'fill' => $cl['text']['rgb'],'stroke-width' => 0, 'font-family' => SVG_FONT, 'font-weight' => 'bold', 'text-anchor' => 'middle' ));
     }
 
     function draw_border()


### PR DESCRIPTION
I noticed svg_options was showing an array to string conversion notice. I traced it back to the stroke on the "Traffic stats for .." heading. So, this fixes it (removes the stroke).
