### PR TITLE
CSS: Dynamically expand hosts & change link coloration

### DIFF
--- a/themes/light/style.css
+++ b/themes/light/style.css
@@ -4,6 +4,18 @@ body
     padding: 0;
 }
 
+a[href]:link,
+a[href]:visited {
+    color: #00f;
+    text-decoration: none;
+}
+a[href]:hover,
+a[href]:active,
+a[href]:focus {
+    color: #c00;
+    text-decoration: none;
+}
+
 #wrap
 {
    xwidth: 868px;
@@ -31,6 +43,10 @@ body
     display: none;
 }
 #sidebar li.iface.active ul
+{
+    display: block;
+}
+#sidebar li.iface:hover ul
 {
     display: block;
 }
@@ -112,7 +128,8 @@ body
 {
     padding: 8px;
     border-left: 1px solid #99b;
-    border-right: 1px solid #99b;    
+    border-right: 1px solid #99b;
+    border-bottom: 1px solid #99b;
     border-collapse: collapse;
 }
 


### PR DESCRIPTION
Some usability improvements which make browsing multiple
hosts/interfaces quite a bit more friendly. Previously-visited pages no
longer appear with purple link-text, in line with more modern web
standards. Host boxes also expand on hover(sort of.... only works going
upwards), which makes it significantly easier to navigate to the desired
interface(one click, not two) or rapidly compare graphs via fwd/back in
a browser
