### PR TITLE
Fix $style inclusion vulnerability

### DIFF
--- a/vnstat.php
+++ b/vnstat.php
@@ -83,7 +83,7 @@
         }
 
 	$tp = "./themes/$style";
-        if (!is_dir($tp) || !file_exists("$tp/theme.php"))
+        if (!is_dir($tp) || !file_exists("$tp/theme.php") || !preg_match('/^[a-z0-9-_]+$/i', $style))
         {
 	    $style = DEFAULT_COLORSCHEME;
         }


### PR DESCRIPTION
Lets say someone creates /tmp/theme.php with malicious input, then goes to
vnstat/?style=../../../../../../../tmp/

It will run /tmp/theme.php

This is very very very bad. I tested it myself with "<?php phpinfo(); exit ?>" as a bad example.

This commit adds regex pattern matching that only allows safe characters 
in the $style variable.