### PR TITLE
Cleaning up code warnings when data or custom iface titles are missing

### DIFF
--- a/graph.php
+++ b/graph.php
@@ -105,7 +105,7 @@
     function draw_grid($x_ticks, $y_ticks)
     {
         global $im, $cl, $iw, $ih, $xlm, $xrm, $ytm, $ybm;
-        $x_step = ($iw - $xlm - $xrm) / $x_ticks;
+        $x_step = ($iw - $xlm - $xrm) / ($x_ticks ?: 1);
         $y_step = ($ih - $ytm - $ybm) / $y_ticks;
 
 	$depth = 10;//($x_step / 8) + 4;
@@ -139,7 +139,7 @@
         $unit = 'K';
         $offset = 0;
         $gr_h = $ih - $ytm - $ybm;
-        $x_step = ($iw - $xlm - $xrm) / $x_ticks;
+        $x_step = ($iw - $xlm - $xrm) / ($x_ticks ?: 1);
         $y_step = ($ih - $ytm - $ybm) / $y_ticks;
         $bar_w = ($x_step / 2) ;
 
@@ -184,7 +184,7 @@
 	imagesetthickness($im, 1);
         $sf = ($prescale * $y_scale * $y_ticks) / $gr_h;
 
-        if ($data[0] == 'nodata')
+        if (count($data) == 0)
         {
             $text = T('no data available');
 	    $bbox = imagettfbbox(10, 0, GRAPH_FONT, $text);

--- a/graph_svg.php
+++ b/graph_svg.php
@@ -165,7 +165,7 @@
     function draw_grid($x_ticks, $y_ticks)
     {
         global $cl, $iw, $ih, $xlm, $xrm, $ytm, $ybm;
-        $x_step = ($iw - $xlm - $xrm) / $x_ticks;
+        $x_step = ($iw - $xlm - $xrm) / ($x_ticks ?: 1);
         $y_step = ($ih - $ytm - $ybm) / $y_ticks;
 
 	$depth = 12*SVG_DEPTH_SCALING;
@@ -203,7 +203,7 @@
         $unit = 'K';
         $offset = 0;
         $gr_h = $ih - $ytm - $ybm;
-        $x_step = ($iw - $xlm - $xrm) / $x_ticks;
+        $x_step = ($iw - $xlm - $xrm) / ($x_ticks ?: 1);
         $y_step = ($ih - $ytm - $ybm) / $y_ticks;
         $bar_w = ($x_step / 2) ;
 
@@ -247,7 +247,7 @@
         //
         $sf = ($prescale * $y_scale * $y_ticks) / $gr_h;
 
-        if ($data[0] == 'nodata')
+        if (count($data) == 0)
         {
             $text = 'no data available';
 	    svg_text($iw/2, $ytm + 80, $text, array( 'stroke' => $cl['text']['rgb'], 'fill' => $cl['text']['rgb'], 'stroke-width' => 0, 'font-family' => SVG_FONT, 'font-size' => '16pt', 'text-anchor' => 'middle') );

--- a/index.php
+++ b/index.php
@@ -165,7 +165,7 @@
 <div id="wrap">
   <div id="sidebar"><?php write_side_bar(); ?></div>
    <div id="content">
-    <div id="header"><?php print T('Traffic data for')." $iface_title[$iface] ($iface)";?></div>
+    <div id="header"><?php print T('Traffic data for').(isset($iface_title[$iface]) ? $iface_title[$iface] : '')." ($iface)";?></div>
     <div id="main">
     <?php
     $graph_params = "if=$iface&amp;page=$page&amp;style=$style";

--- a/index.php
+++ b/index.php
@@ -89,25 +89,30 @@
         //
         // build array for write_data_table
         //
-        $sum[0]['act'] = 1;
-        $sum[0]['label'] = T('This hour');
-        $sum[0]['rx'] = $hour[0]['rx'];
-        $sum[0]['tx'] = $hour[0]['tx'];
 
-        $sum[1]['act'] = 1;
-        $sum[1]['label'] = T('This day');
-        $sum[1]['rx'] = $day[0]['rx'];
-        $sum[1]['tx'] = $day[0]['tx'];
+        $sum = array();
 
-        $sum[2]['act'] = 1;
-        $sum[2]['label'] = T('This month');
-        $sum[2]['rx'] = $month[0]['rx'];
-        $sum[2]['tx'] = $month[0]['tx'];
+        if (count($day) > 0 && count($hour) > 0 && count($month) > 0) {
+            $sum[0]['act'] = 1;
+            $sum[0]['label'] = T('This hour');
+            $sum[0]['rx'] = $hour[0]['rx'];
+            $sum[0]['tx'] = $hour[0]['tx'];
 
-        $sum[3]['act'] = 1;
-        $sum[3]['label'] = T('All time');
-        $sum[3]['rx'] = $trx;
-        $sum[3]['tx'] = $ttx;
+            $sum[1]['act'] = 1;
+            $sum[1]['label'] = T('This day');
+            $sum[1]['rx'] = $day[0]['rx'];
+            $sum[1]['tx'] = $day[0]['tx'];
+
+            $sum[2]['act'] = 1;
+            $sum[2]['label'] = T('This month');
+            $sum[2]['rx'] = $month[0]['rx'];
+            $sum[2]['tx'] = $month[0]['tx'];
+
+            $sum[3]['act'] = 1;
+            $sum[3]['label'] = T('All time');
+            $sum[3]['rx'] = $trx;
+            $sum[3]['tx'] = $ttx;
+        }
 
         write_data_table(T('Summary'), $sum);
         print "<br/>\n";

--- a/vnstat.php
+++ b/vnstat.php
@@ -123,6 +123,10 @@
         $month = array();
         $top = array();
 
+        if (strpos($vnstat_data[0], 'Error') !== false) {
+          return;
+        }
+
         //
         // extract data
         //
@@ -199,16 +203,9 @@
                 $summary[$d[0]] = isset($d[1]) ? $d[1] : '';
             }
         }
-        if (count($day) == 0)
-            $day[0] = 'nodata';
+
         rsort($day);
-
-        if (count($month) == 0)
-            $month[0] = 'nodata';
         rsort($month);
-
-        if (count($hour) == 0)
-            $hour[0] = 'nodata';
         rsort($hour);
     }
 ?>


### PR DESCRIPTION
Say you mispell your iface name in the config, or try to target a device that
vnstat is not configured to monitor, you will get lots of the following:

```PHP Warning:  Illegal string offset 'rx' in /home/joe/public_html/vnstat-php-frontend/index.php on line 104
PHP Warning:  Illegal string offset 'tx' in /home/joe/public_html/vnstat-php-frontend/index.php on line 105```

This patch checks if vnstat gives an error. If it does, it leaves the $hour/$month/$day
variables empty rather than making them 'nodata'.

In places where data is expected (in the graphs and table generation) the
time variables are now checked against being empty rather than 'nodata' which further
fixes warnings like the following:

```PHP Notice:  Undefined index: totalrx in /home/joe/public_html/vnstat-php-frontend/index.php on line 86
PHP Notice:  Undefined index: totalrxk in /home/joe/public_html/vnstat-php-frontend/index.php on line 86
PHP Notice:  Undefined index: totaltx in /home/joe/public_html/vnstat-php-frontend/index.php on line 87
PHP Notice:  Undefined index: totaltxk in /home/joe/public_html/vnstat-php-frontend/index.php on line 87```

Additionally, this patch fixes the following warning you get when you don't specify an iface title:

```PHP Notice:  Undefined index: sixxs in /home/joe/public_html/vnstat-php-frontend/index.php on line 168```