### PR TITLE
Ability to specify what unit of byte measurement you want

### DIFF
--- a/config.php
+++ b/config.php
@@ -63,6 +63,10 @@
     // graphics format to use: svg or png
     $graph_format='svg';
 
+    // preferred byte notation. null auto chooses. otherwise use one of
+    // 'TB','GB','MB','KB'
+    $byte_notation = null;
+
     // Font to use for PNG graphs
     define('GRAPH_FONT',dirname(__FILE__).'/VeraBd.ttf');
 

--- a/index.php
+++ b/index.php
@@ -67,15 +67,25 @@
 
     function kbytes_to_string($kb)
     {
+
+        global $byte_notation;
+
         $units = array('TB','GB','MB','KB');
         $scale = 1024*1024*1024;
         $ui = 0;
 
-        while (($kb < $scale) && ($scale > 1))
+        $custom_size = isset($byte_notation) && in_array($byte_notation, $units);
+
+        while ((($kb < $scale) && ($scale > 1)) || $custom_size)
         {
             $ui++;
             $scale = $scale / 1024;
+
+            if ($custom_size && $units[$ui] == $byte_notation) {
+                break;
+            }
         }
+
         return sprintf("%0.2f %s", ($kb/$scale),$units[$ui]);
     }
 


### PR DESCRIPTION
Per #25 

Add a new (self explanatory) option to config.php letting you consistently choose what version you want, defaulting to the current behavior of auto deciding.

```php
// preferred byte notation. null auto chooses. otherwise use one of
// 'TB','GB','MB','KB'
$byte_notation = null;
```